### PR TITLE
Add user guess feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Visitor Counter Site
+
+This project is a simple web page that guesses how many visitors came before you. It uses Firebase Realtime Database to keep a counter and Formspree to collect e‑mail addresses.
+
+## Running the site
+
+Open `index.html` in a browser or serve the directory with any static file server. The page will display four options asking what visitor number you think you are. After choosing an option, the page asks for your e‑mail to show the real visitor number.
+
+After you submit your email, the page shows the guess you selected and the actual visitor number. It also tells you whether you guessed correctly with "Tebrikler, bildiniz!" or "Üzgünüm, bilemedin."
+
+## Firebase configuration
+
+The Firebase keys included in `script.js` are intended for public client use. Make sure to restrict their usage in the Firebase console (e.g. domain restrictions) to prevent abuse.
+
+## Collecting e‑mails
+
+Form submissions are sent to Formspree. Replace the `action` attribute of the form with your own Formspree endpoint if needed.

--- a/index.html
+++ b/index.html
@@ -20,12 +20,13 @@
     <form id="form" action="https://formspree.io/f/xwpodpor" method="POST">
       <input type="email" name="email" required placeholder="Email adresiniz" />
       <input type="hidden" name="realAnswer" id="realAnswer" />
+      <input type="hidden" name="userGuess" id="userGuess" />
       <button type="submit">Sonucu Gör</button>
     </form>
   </div>
 
   <div id="result" class="hidden"></div>
 
-  <<script type="module" src="script.js"></script>t>
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -39,7 +39,9 @@ export async function initCounter() {
 function generateOptions(correct) {
   const options = new Set([correct]);
   while (options.size < 4) {
-    options.add(correct + Math.floor(Math.random() * 20 - 10));
+    const offset = Math.floor(Math.random() * 20) - 10;
+    const guess = Math.max(1, correct + offset);
+    options.add(guess);
   }
   return Array.from(options).sort(() => Math.random() - 0.5);
 }
@@ -48,17 +50,47 @@ function setupPage(visitorNumber) {
   const optionsDiv = document.getElementById('options');
   const emailForm = document.getElementById('emailForm');
   const realAnswerInput = document.getElementById('realAnswer');
+  const userGuessInput = document.getElementById('userGuess');
+  const resultDiv = document.getElementById('result');
+  const form = document.getElementById('form');
+
+  let userGuess = null;
 
   const options = generateOptions(visitorNumber);
   options.forEach(opt => {
     const btn = document.createElement('button');
     btn.textContent = opt;
     btn.onclick = () => {
+      userGuess = opt;
       realAnswerInput.value = visitorNumber;
+      userGuessInput.value = opt;
       emailForm.classList.remove('hidden');
       optionsDiv.classList.add('hidden');
     };
     optionsDiv.appendChild(btn);
+  });
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const data = new FormData(form);
+    try {
+      await fetch(form.action, {
+        method: 'POST',
+        body: data,
+        headers: { 'Accept': 'application/json' }
+      });
+    } catch (err) {
+      console.error('Form submission failed:', err);
+    }
+    emailForm.classList.add('hidden');
+    let text = `Seçiminiz: ${userGuess}. Gerçek ziyaretçi numarası: ${visitorNumber}. `;
+    if (userGuess === visitorNumber) {
+      text += 'Tebrikler, bildiniz!';
+    } else {
+      text += 'Üzgünüm, bilemedin.';
+    }
+    resultDiv.textContent = text;
+    resultDiv.classList.remove('hidden');
   });
 }
 


### PR DESCRIPTION
## Summary
- show both the selected option and the real visitor number after email is submitted
- respond with `Tebrikler, bildiniz!` or `Üzgünüm, bilemedin.`
- save the user's guess in a hidden form field
- document the behavior in the README

## Testing
- `npm test` *(fails: package.json missing)*